### PR TITLE
Combined changes to get IPv6 single stack running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ kind-up kind-down gardener-up gardener-down register-local-env tear-down-local-e
 kind2-up kind2-down gardenlet-kind2-up gardenlet-kind2-down: export KUBECONFIG = $(GARDENER_LOCAL2_KUBECONFIG)
 
 kind-up: $(KIND) $(KUBECTL)
-	mkdir -m 775 -p $(REPO_ROOT)/dev/local-backupbuckets $(REPO_ROOT)/dev/local-registry
+	mkdir -m 777 -p $(REPO_ROOT)/dev/local-backupbuckets $(REPO_ROOT)/dev/local-registry
 	$(KIND) create cluster --name gardener-local --config $(REPO_ROOT)/example/gardener-local/kind/cluster-$(KIND_ENV)$(IPV6_SUFFIX).yaml --kubeconfig $(KUBECONFIG)
 	docker exec gardener-local-control-plane sh -c "sysctl fs.inotify.max_user_instances=8192" # workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 	cp $(KUBECONFIG) $(REPO_ROOT)/example/provider-local/seed-kind/base/kubeconfig

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -103,8 +103,8 @@ images:
   tag: "0.20.0"
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2
-  repository: eu.gcr.io/gardener-project/gardener/vpn-seed-server
-  tag: "0.10.0"
+  repository: docker.io/einfachnuralex/vpn-seed-server
+  tag: "0.12.0-dev7"
 
 # Monitoring
 - name: alertmanager
@@ -159,11 +159,11 @@ images:
   tag: "0.20.0"
 - name: vpn-shoot-client
   sourceRepository: github.com/gardener/vpn2
-  repository: eu.gcr.io/gardener-project/gardener/vpn-shoot-client
-  tag: "0.10.0"
+  repository: registry.ipv6.docker.com/einfachnuralex/vpn-shoot-client
+  tag: "0.12.0-dev7"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
-  repository: coredns/coredns
+  repository: registry.ipv6.docker.com/coredns/coredns
   tag: "1.9.3"
 - name: node-local-dns
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns
@@ -225,7 +225,7 @@ images:
 
 # Miscellaenous
 - name: alpine
-  repository: alpine
+  repository: registry.ipv6.docker.com/library/alpine
   tag: "3.15.4"
 - name: alpine-iptables
   sourceRepository: github.com/gardener/alpine-iptables
@@ -255,7 +255,7 @@ images:
   tag: v0.13.0
 - name: promtail
   sourceRepository: github.com/grafana/loki
-  repository: "docker.io/grafana/promtail"
+  repository: "registry.ipv6.docker.com/grafana/promtail"
   tag: "2.2.1"
 - name: telegraf
   sourceRepository: github.com/gardener/logging
@@ -315,7 +315,7 @@ images:
 # API Server SNI
 - name: apiserver-proxy
   sourceRepository: github.com/envoyproxy/envoy
-  repository: envoyproxy/envoy-distroless
+  repository: registry.ipv6.docker.com/envoyproxy/envoy-distroless
   tag: "v1.23.1"
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -319,9 +319,9 @@ images:
   tag: "v1.23.1"
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
-  repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
-  tag: "v0.6.0"
+  repository: registry.ipv6.docker.com/einfachnuralex/apiserver-proxy
+  tag: "v0.9.0-dev1-32f2e0273215a1184b6ee25e19e9c9a5ecd895cd"
 - name: apiserver-proxy-pod-webhook
   sourceRepository: github.com/gardener/apiserver-proxy
-  repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook
-  tag: "v0.6.0"
+  repository: registry.ipv6.docker.com/einfachnuralex/apiserver-proxy-pod-webhook
+  tag: "v0.9.0-dev1-32f2e0273215a1184b6ee25e19e9c9a5ecd895cd"

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
@@ -63,7 +63,7 @@ envoy.yaml: |-
     - name: metrics
       address:
         socket_address:
-          address: 0.0.0.0
+          address: "::"
           port_value: {{ .Values.adminPort }}
       filter_chains:
       - filters:
@@ -110,7 +110,7 @@ envoy.yaml: |-
       connect_timeout: 5s
       per_connection_buffer_limit_bytes: 32768 # 32 KiB
       type: LOGICAL_DNS
-      dns_lookup_family: V4_ONLY
+      dns_lookup_family: AUTO
       lb_policy: ROUND_ROBIN
       load_assignment:
         cluster_name: kube_apiserver

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -30,6 +30,8 @@ spec:
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
+    - ipBlock:
+        cidr: ::/0        
     - podSelector:
         matchExpressions:
         - {key: k8s-app, operator: In, values: [node-local-dns]}

--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -16,13 +16,10 @@ package app
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"net"
 	"os"
 	"time"
-
-	"github.com/spf13/pflag"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 
@@ -70,7 +67,6 @@ import (
 // NewControllerManagerCommand creates a new command for running a local provider controller.
 func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	var (
-		is6      = flag.Bool("is6", false, "Provider should work with IPv6")
 		restOpts = &controllercmd.RESTOptions{}
 		mgrOpts  = &controllercmd.ManagerOptions{
 			LeaderElection:             true,
@@ -210,7 +206,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			metav1.AddToGroupVersion(scheme, machinev1alpha1.SchemeGroupVersion)
 
 			// Set HostIP
-			hostIP, err := getHostIP(*is6)
+			hostIP, err := getHostIP(true)
 			if err != nil {
 				return err
 			}
@@ -270,9 +266,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	is6Flag := flag.Lookup("is6")
-	is6PFlag := pflag.PFlagFromGoFlag(is6Flag)
-	cmd.Flags().AddFlag(is6PFlag)
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -19,6 +19,45 @@ Based on [Skaffold](https://skaffold.dev/), the container images for all require
   Additionally, please configure at least `120Gi` of disk size for the Docker daemon.
   > Tip: With `docker system df` and `docker system prune -a` you can cleanup unused data.
 
+## IPv6 Singe Stack
+
+If you want to try **IPv6** local setup you must `export USE_IPV6=1` before setting up kind and be sure that `/etc/hosts` contains `::1 localhost`.
+
+Also we need to configure NAT for the kind network. After `make kind-up` check network created by kind.
+
+```
+docker network inspect kind | jq '.[].IPAM.Config[].Subnet'
+```
+
+Output sample:
+```bash
+"172.18.0.0/16"
+"fc00:f853:ccd:e793::/64"
+```
+
+Check your network interface with default route
+
+```bash
+ip r s default 
+```
+
+Output sample:
+
+```bash
+default via 192.168.195.1 dev enp3s0 proto dhcp src 192.168.195.34 metric 100
+```
+
+Now get interface name and IPv6 subnet and build iptables command
+
+```bash
+ip6tables -t nat -A POSTROUTING -o $INTERFACE -s $SUBNET -j MASQUERADE
+```
+
+Complete command with samples, maybe you need to run the command with `sudo`:
+```bash
+ip6tables -t nat -A POSTROUTING -o enp3s0 -s fc00:f853:ccd:e793::/64 -j MASQUERADE
+```
+
 ## Setting up the KinD cluster (garden and seed)
 
 ```bash

--- a/example/gardener-local/calico-ipv6/patch-calico-node-daemonset.yaml
+++ b/example/gardener-local/calico-ipv6/patch-calico-node-daemonset.yaml
@@ -2,19 +2,19 @@
   path: /spec/template/spec/containers/0/env/-
   value: 
     name: IP6
-    value: autodetect
+    value: "autodetect"
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value: 
     name: CALICO_IPV6POOL_NAT_OUTGOING
-    value: true
+    value: "true"
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value: 
     name: CALICO_NAT_OUTGOING
-    value: true
+    value: "true"
 - op: replace
-  path: /spec/template/spec/containers/0/env/17
+  path: /spec/template/spec/containers/0/env/14
   value: 
     name: FELIX_IPV6SUPPORT
-    value: true
+    value: "true"

--- a/example/gardener-local/controlplane/auth-webhook-kubeconfig-skaffold.yaml
+++ b/example/gardener-local/controlplane/auth-webhook-kubeconfig-skaffold.yaml
@@ -5,7 +5,7 @@ clusters:
   cluster:
     insecure-skip-tls-verify: true
     # This is the IP of the `gardener-admission-controller` service in the `garden` namespace.
-    server: https://10.2.2.10/webhooks/auth/seed
+    server: https://[fc00:10:96::1000]/webhooks/auth/seed
 users:
 - name: kube-apiserver
   user: {}

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -167,7 +167,7 @@ global:
   admission:
     enabled: true
     service:
-      clusterIP: 10.2.2.10
+      clusterIP: fc00:10:96::1000
     seedRestriction:
       enabled: true
     config:

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -15,7 +15,7 @@ global:
             clusters:
             - cluster:
                 insecure-skip-tls-verify: true
-                server: https://gardener-local-control-plane:6443
+                server: https://kubernetes.default.svc:443
               name: default
             contexts:
             - context:

--- a/example/gardener-local/kind/cluster-skaffold-ipv6.yaml
+++ b/example/gardener-local/kind/cluster-skaffold-ipv6.yaml
@@ -1,0 +1,69 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  image: kindest/node:v1.24.6
+  extraPortMappings:
+  # istio-ingressgateway
+  - containerPort: 30443
+    hostPort: 443
+  # etcd (for gardener-apiserver)
+  - containerPort: 32379
+    hostPort: 32379
+  # ingress-nginx (Seed)
+  - containerPort: 30448
+    hostPort: 8448
+  # registry for locally built images
+  - containerPort: 5001
+    hostPort: 5001
+  extraMounts:
+  - hostPath: example/gardener-local/controlplane
+    containerPath: /etc/gardener/controlplane
+    readOnly: true
+  - hostPath: dev/local-backupbuckets
+    containerPath: /etc/gardener/local-backupbuckets
+  - hostPath: dev/local-registry
+    containerPath: /etc/gardener/local-registry
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        authorization-mode: RBAC,Node,Webhook
+        authorization-webhook-config-file: /etc/gardener/controlplane/auth-webhook-kubeconfig-skaffold.yaml
+        authorization-webhook-cache-authorized-ttl: "0"
+        authorization-webhook-cache-unauthorized-ttl: "0"
+      extraVolumes:
+      - name: gardener
+        hostPath: /etc/gardener/controlplane/auth-webhook-kubeconfig-skaffold.yaml
+        mountPath: /etc/gardener/controlplane/auth-webhook-kubeconfig-skaffold.yaml
+        readOnly: true
+        pathType: File
+  - |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    maxPods: 500
+    serializeImagePulls: false
+    registryPullQPS: 10
+    registryBurst: 20
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://gardener-local-control-plane:5001"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+    endpoint = ["http://gardener-local-control-plane:5002"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."gcr.io"]
+    endpoint = ["http://gardener-local-control-plane:5003"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."eu.gcr.io"]
+    endpoint = ["http://gardener-local-control-plane:5004"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+    endpoint = ["http://gardener-local-control-plane:5005"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
+    endpoint = ["http://gardener-local-control-plane:5006"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+    endpoint = ["http://gardener-local-control-plane:5007"]
+networking:
+  disableDefaultCNI: true # disable kindnet since we install calico for network policy support
+  ipFamily: ipv6
+  podSubnet: fc00:10:244::/56
+  serviceSubnet: fc00:10:96::/112

--- a/example/provider-local/garden/base/patch-controller-deployment.yaml
+++ b/example/provider-local/garden/base/patch-controller-deployment.yaml
@@ -7,4 +7,71 @@ providerConfig:
     image:
       # TODO(shafeeqes): Use v1.27.0 image in the resources once it's released.
       # Currently dev image is used to include https://github.com/gardener/gardener-extension-networking-calico/pull/210
-      tag: v1.27.0-dev-6e539ffcb2a52c926be99bed5c5681ab08f15d40
+      repository: docker.io/einfachnuralex/networking-calico
+      tag: v1.27.0-dev-1acc062002d35cb0ef12fe1cb826b21b5af238f7
+    imageVectorOverwrite: |
+      images:
+      - name: calico-node
+        sourceRepository: github.com/projectcalico/calico
+        repository: registry.ipv6.docker.com/calico/node
+        tag: v3.23.3
+        targetVersion: ">= 1.21"
+      - name: calico-node
+        sourceRepository: github.com/projectcalico/calico
+        repository: registry.ipv6.docker.com/calico/node
+        tag: v3.22.2
+        targetVersion: "< 1.21"
+      - name: calico-cni
+        sourceRepository: github.com/projectcalico/cni-plugin
+        repository: registry.ipv6.docker.com/calico/cni
+        tag: v3.23.3
+        targetVersion: ">= 1.21"
+      - name: calico-cni
+        sourceRepository: github.com/projectcalico/cni-plugin
+        repository: registry.ipv6.docker.com/calico/cni
+        tag: v3.22.2
+        targetVersion: "< 1.21"
+      - name: calico-typha
+        sourceRepository: github.com/projectcalico/typha
+        repository: registry.ipv6.docker.com/calico/typha
+        tag: v3.23.3
+        targetVersion: ">= 1.21"
+        labels:
+        - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+          value:
+            policy: skip
+            comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
+      - name: calico-typha
+        sourceRepository: github.com/projectcalico/typha
+        repository: registry.ipv6.docker.com/calico/typha
+        tag: v3.22.2
+        targetVersion: "< 1.21"
+        labels:
+        - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+          value:
+            policy: skip
+            comment: payload are two statically linked ELF-binaries and some configuration/license files - not suitable for binary-id-scanning
+      - name: calico-kube-controllers
+        sourceRepository: github.com/projectcalico/kube-controllers
+        repository: registry.ipv6.docker.com/calico/kube-controllers
+        tag: v3.23.3
+        targetVersion: ">= 1.21"
+      - name: calico-kube-controllers
+        sourceRepository: github.com/projectcalico/kube-controllers
+        repository: registry.ipv6.docker.com/calico/kube-controllers
+        tag: v3.22.2
+        targetVersion: "< 1.21"
+      - name: calico-podtodaemon-flex
+        sourceRepository: github.com/projectcalico/pod2daemon
+        repository: registry.ipv6.docker.com/calico/pod2daemon-flexvol
+        tag: v3.22.2
+        # targetVersion is removed to avoid a panic in imagevector.findImage function.
+        # targetVersion: "< 1.21"
+      - name: calico-cpa
+        sourceRepository: github.com/kubernetes-sigs/cluster-proportional-autoscaler
+        repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
+        tag: 1.8.6
+      - name: calico-cpva
+        sourceRepository: github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler
+        repository: k8s.gcr.io/cpa/cpvpa
+        tag: v0.8.4

--- a/example/provider-local/shoot-ipv6.yaml
+++ b/example/provider-local/shoot-ipv6.yaml
@@ -16,9 +16,11 @@ spec:
     providerConfig:
       apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
       kind: NetworkConfig
-      backend: none
+      backend: bird
       typha:
         enabled: false
+      ipv6:
+        autoDetectionMethod: kubernetes-internal-ip
     pods: 2001:0db8:1234::/112
     nodes: 2001:0db8:1235::/56
     services: 2001:0db8:1236::/112

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -524,7 +524,7 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
+        name: "::_8132"
         portNumber: 8132
         filterChain:
           filter:
@@ -556,7 +556,7 @@ spec:
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
-        name: 0.0.0.0_8132
+        name: "::_8132"
         portNumber: 8132
     patch:
       operation: MERGE
@@ -581,7 +581,7 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: 0.0.0.0_8132
+        name: "::_8132"
         portNumber: 8132
         filterChain:
           filter:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -524,7 +524,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: "::_8132"
         portNumber: 8132
         filterChain:
           filter:
@@ -556,7 +555,6 @@ spec:
         filterChain:
           filter:
             name: envoy.filters.network.http_connection_manager
-        name: "::_8132"
         portNumber: 8132
     patch:
       operation: MERGE
@@ -581,7 +579,6 @@ spec:
     match:
       context: GATEWAY
       listener:
-        name: "::_8132"
         portNumber: 8132
         filterChain:
           filter:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
@@ -16,7 +16,7 @@ spec:
       context: GATEWAY
       listener:
         portNumber: 8443
-        name: 0.0.0.0_8443
+        name: "::_8443"
     patch:
       operation: MERGE
       value:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
@@ -16,7 +16,6 @@ spec:
       context: GATEWAY
       listener:
         portNumber: 8443
-        name: "::_8443"
     patch:
       operation: MERGE
       value:

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -142,6 +142,7 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 						{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
 						// kube-apiserver can be accessed from anywhere using the LoadBalancer.
 						{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
+						{IPBlock: &networkingv1.IPBlock{CIDR: "::/0"}},
 					},
 					Ports: []networkingv1.NetworkPolicyPort{{
 						Protocol: &protocol,

--- a/pkg/operation/botanist/component/kubeapiserverexposure/templates/envoyfilter.yaml
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/templates/envoyfilter.yaml
@@ -23,7 +23,7 @@ spec:
       context: ANY
       listener:
         portNumber: 8443
-        name: 0.0.0.0_8443
+        name: "::_8443"
     patch:
       operation: ADD
       value:
@@ -37,4 +37,4 @@ spec:
           destination_port: {{ .Port }}
           prefix_ranges:
           - address_prefix: {{ .APIServerClusterIP }}
-            prefix_len: 32
+            prefix_len: 128

--- a/pkg/operation/botanist/component/kubeapiserverexposure/templates/envoyfilter.yaml
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/templates/envoyfilter.yaml
@@ -23,7 +23,6 @@ spec:
       context: ANY
       listener:
         portNumber: 8443
-        name: "::_8443"
     patch:
       operation: ADD
       value:

--- a/pkg/operation/botanist/component/networkpolicies/global.go
+++ b/pkg/operation/botanist/component/networkpolicies/global.go
@@ -364,17 +364,25 @@ func getGlobalNetworkPolicyTransformers(values GlobalValues) []networkPolicyTran
 							},
 						},
 						Egress: []networkingv1.NetworkPolicyEgressRule{{
-							To: []networkingv1.NetworkPolicyPeer{{
-								IPBlock: &networkingv1.IPBlock{
-									CIDR: "0.0.0.0/0",
-									Except: append([]string{
-										Private8BitBlock().String(),
-										Private12BitBlock().String(),
-										Private16BitBlock().String(),
-										CarrierGradeNATBlock().String(),
-									}, values.BlockedAddresses...),
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "0.0.0.0/0",
+										Except: append([]string{
+											Private8BitBlock().String(),
+											Private12BitBlock().String(),
+											Private16BitBlock().String(),
+											CarrierGradeNATBlock().String(),
+										}, values.BlockedAddresses...),
+									},
 								},
-							}},
+								{
+									//TODO(nschad): Add except Block for ipv6 like for ipv4? What about BlockedAddresses?!
+									IPBlock: &networkingv1.IPBlock{
+										CIDR: "::/0",
+									},
+								},
+							},
 						}},
 						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 					}

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -353,6 +353,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.Bool(true),
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
 										"NET_ADMIN",
@@ -424,6 +425,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 							Image:           v.imageAPIServerProxy,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.Bool(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"all",
@@ -759,7 +761,7 @@ var envoyConfig = `static_resources:
       socket_address:
         protocol: TCP
         address: "::"
-        ipv4_compat: true
+        ipv4_compat: false
         port_value: ` + fmt.Sprintf("%d", EnvoyPort) + `
     listener_filters:
     - name: "envoy.filters.listener.tls_inspector"
@@ -824,7 +826,7 @@ var envoyConfig = `static_resources:
               "@type": type.googleapis.com/envoy.extensions.filters.http.dynamic_forward_proxy.v3.FilterConfig
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
-                dns_lookup_family: V4_ONLY
+                dns_lookup_family: V6_ONLY
                 max_hosts: 8192
           - name: envoy.filters.http.router
             typed_config:
@@ -837,7 +839,7 @@ var envoyConfig = `static_resources:
     address:
       socket_address:
         address: "::"
-        ipv4_compat: true
+        ipv4_compat: false
         port_value: ` + fmt.Sprintf("%d", envoyMetricsPort) + `
     filter_chains:
     - filters:
@@ -877,7 +879,7 @@ var envoyConfig = `static_resources:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
-          dns_lookup_family: V4_ONLY
+          dns_lookup_family: V6_ONLY
           max_hosts: 8192
   - name: prometheus_stats
     connect_timeout: 0.25s

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -418,7 +418,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN, secretVPNShoot *corev1.Secr
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Env:             v.getEnvVars(),
 								SecurityContext: &corev1.SecurityContext{
-									Privileged: pointer.Bool(!v.values.ReversedVPN.Enabled),
+									Privileged: pointer.Bool(true),
 									Capabilities: &corev1.Capabilities{
 										Add: []corev1.Capability{"NET_ADMIN"},
 									},

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -9,9 +9,9 @@ images:
   tag: sha-1c148ce
 - name: local-path-provisioner
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-provisioner
-  repository: docker.io/kindest/local-path-provisioner
+  repository: registry.ipv6.docker.com/kindest/local-path-provisioner
   tag: v0.0.22-kind.0
 - name: local-path-helper
   sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-helper
-  repository: docker.io/kindest/local-path-helper
+  repository: registry.ipv6.docker.com/kindest/local-path-helper
   tag: v20220512-507ff70b


### PR DESCRIPTION
Hey, we finally made it to :100: `Shoot cluster has been successfully reconciled` :partying_face:

Some changes to highlight:
- is6 flag in provider-local doesn't word for us, hardcode it to true for testing
- changed docker.io images running on Shoot to registry.ipv6.docker.com, read: [Beta IPv6 Support on Docker Hub Registry](https://www.docker.com/blog/beta-ipv6-support-on-docker-hub-registry/)
- Add `::/0` to NetworkPolicies to make local setup work
- Need IPv6 NAT on local machine, read docs/deployment/getting_started_locally.md
- patched Calico extension: https://github.com/gardener/gardener-extension-networking-calico/pull/216
- patched VPN container: https://github.com/ScheererJ/vpn2/pull/1
- done some `0.0.0.0` to `::` replacements :smile: 

Problems:
- Loki has no IPv6 support, https://github.com/grafana/loki/issues/6251
- ~~Machine pod has a route `fc00:10::/32` set, which prevents communication. We found no way to avoid this. The route is set when the apiserver-proxy sets it's virtual IP on the lo interface.~~
  - ~~This is the only manual step! Exec into machine pod and run `ip -6 r del fc00:10::/32`~~